### PR TITLE
Fixed endpoints for TIP data and Connections 2045 Planning Centers

### DIFF
--- a/src/components/map/Map.js
+++ b/src/components/map/Map.js
@@ -173,7 +173,7 @@ class MapComponent extends Component {
       this.map.addSource("Connections", {
         type: "geojson",
         data:
-          "https://opendata.arcgis.com/datasets/75a9bee3b74e44c791388a2cd775f3b7_0.geojson"
+          "https://opendata.arcgis.com/datasets/24b5bbdfdf6d4930ad34c23012e7fb2a_0.geojson"
       });
       this.map.addLayer(
         {

--- a/src/components/reducers/getTIPInfo.js
+++ b/src/components/reducers/getTIPInfo.js
@@ -55,7 +55,7 @@ export const getTIPByKeywords = keyword => dispatch => {
           where: `MPMS_ID in (${mpms_array})`,
           srOut: 4326,
           f: "pjson",
-          outFields: "FID,CTY,MPMS_ID,ROAD_NAME,DESCRIPTIO,LAG,LNG",
+          outFields: "OBJECTID,CTY,MPMS_ID,ROAD_NAME,DESCRIPTIO,LAG,LNG",
           returnGeometry: false
         };
         //Encode the data
@@ -67,7 +67,7 @@ export const getTIPByKeywords = keyword => dispatch => {
           })
           .join("&");
         fetch(
-          `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/Draft_DVRPC_PATIP_FY2019_2022_points/FeatureServer/0/query`,
+          `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/DVRPC_Pennsylvania_Transportation_Improvement_Program_(TIP)_2019-2022/FeatureServer/0/query`,
           {
             headers: {
               "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8"
@@ -97,8 +97,8 @@ export const getTIPByKeywords = keyword => dispatch => {
                 ) {
                   const formattedKeywordObject = {
                     attributes: {
-                      // sham FID to act as a key for the tile
-                      FID: project.id + project.road_name,
+                      // sham OBJECTID to act as a key for the tile
+                      OBJECTID: project.id + project.road_name,
                       CTY: project.county,
                       DESCRIPTIO: project.category,
                       MPMS_ID: project.id,
@@ -139,7 +139,7 @@ export const setFilter = category => dispatch => {
 // get all projects within the boundaires of the current mapbox view
 export const getTIPByMapBounds = bounds => dispatch => {
   fetch(
-    `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/Draft_DVRPC_PATIP_FY2019_2022_points/FeatureServer/0/query?geometry=${bounds}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=false&outSR=4326&f=json`
+    `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/DVRPC_Pennsylvania_Transportation_Improvement_Program_(TIP)_2019-2022/FeatureServer/0/query?geometry=${bounds}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=*&returnGeometry=false&outSR=4326&f=json`
   ).then(response =>
     response.json().then(projects => dispatch(get_tip_by_map_bounds(projects)))
   );
@@ -148,7 +148,7 @@ export const getTIPByMapBounds = bounds => dispatch => {
 // pull project information from URL for link sharing
 export const hydrateGeometry = id => dispatch => {
   fetch(
-    `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/Draft_DVRPC_PATIP_FY2019_2022_points/FeatureServer/0/query?where=MPMS_ID=${id}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=LAG,LNG&returnGeometry=false&outSR=4326&f=json`
+    `https://services1.arcgis.com/LWtWv6q6BJyKidj8/arcgis/rest/services/DVRPC_Pennsylvania_Transportation_Improvement_Program_(TIP)_2019-2022/FeatureServer/0/query?where=MPMS_ID=${id}&geometryType=esriGeometryEnvelope&inSR=4326&spatialRel=esriSpatialRelIntersects&outFields=LAG,LNG&returnGeometry=false&outSR=4326&f=json`
   )
     .then(response => {
       if (response.ok)

--- a/src/components/tiles-container/TilesContainer.js
+++ b/src/components/tiles-container/TilesContainer.js
@@ -86,7 +86,7 @@ class TilesContainer extends Component {
         </div>
         {projects ? (
           projects.map(feature => (
-            <Tile data={feature} key={feature.attributes.FID} />
+            <Tile data={feature} key={feature.attributes.OBJECTID} />
           ))
         ) : (
           <img id="no-results" src={loading} alt="loading" />


### PR DESCRIPTION
Fixes #59 

- Changed TIP data endpoint to DVRPC's GIS Open Data Portal 
- Changed appropriate field names to reflect new file
- Changed source for Connections 2045 Planning Centers to point to new endpoint on DVRPC's GIS Open Data Portal 